### PR TITLE
Remove typo

### DIFF
--- a/src/routes/docs/2.api/helpers/index.md
+++ b/src/routes/docs/2.api/helpers/index.md
@@ -2,5 +2,5 @@ Helpers can be imported from `@roxi/routify`:
 
 ```javascript
 // example
-import { $url } from '@roxi/routify'
+import { url } from '@roxi/routify'
 ```


### PR DESCRIPTION
The $ prefix is reserved, and cannot be used for variable and import names.  The actual exported name is url without $